### PR TITLE
fix: golang -> under-the-hood

### DIFF
--- a/website/make-cn.go
+++ b/website/make-cn.go
@@ -213,7 +213,7 @@ func walkDocsForHierarchy(path string, info os.FileInfo, err error) error {
 		panic(fmt.Errorf("walkDocsForHierarchy: expect numbers for weight: %v", err))
 	}
 	title := doc[:endIdx-1]
-	url := strings.Replace(path, "content", "/golang", -1)
+	url := strings.Replace(path, "content", "/under-the-hood", -1)
 	url = strings.Replace(url, ".md", "", -1)
 	url = strings.Replace(url, "_index", "", -1)
 	hierarchy = append(hierarchy, section{


### PR DESCRIPTION
## 说明

上一节，下一节的根路径错误：`https://golang.design/golang/zh-cn/part1basic/`

应该为 `https://golang.design/under-the-hood/zh-cn/part1basic/`

## 变化箱单

- 修复了 所有上一节、下一节的链接地址
