### PR TITLE
bugfix: cas change p

### DIFF
--- a/gosrc/sync/map.go
+++ b/gosrc/sync/map.go
@@ -66,7 +66,9 @@ type entry struct {
 	//
 	// 否则，entry 仍然有效，且被记录在 m.read.m[key] ，但如果 m.dirty != nil，则在 m.dirty[key] 中
 	//
-	// 一个 entry 可以被原子替换为 nil 来删除：当 m.dirty 是下一个创建的，它会自动将 nil 替换为 expunged 且
+	// 一个 entry 的 p 字段 可以被原子替换为 nil 来标记删除， 重建 dirty 时跳过 nil 标记的 entry，
+	// 然后在 dirty 提升为 read 时真正实现删除
+	// 当 m.dirty 是下一个创建的，它会自动将 nil 替换为 expunged 且
 	// 让 m.dirty[key] 成为未设置的状态。
 	//
 	// 与一个 entry 关联的值可以被原子替换式的更新，提供的 p != expunged。如果 p == expunged，


### PR DESCRIPTION
resolve #42 

## 说明

fix the expression about how to delete a key in `sync.map` if it exists in `read`。

## 变化箱单

- 解决了关于`sync.map`中`read`的key的删除过程的描述性错误

## 参考文献

无
