### PR TITLE
book: fix ch06sched preemption typo (#46)

### DIFF
--- a/book/zh-cn/part2runtime/ch06sched/preemption.md
+++ b/book/zh-cn/part2runtime/ch06sched/preemption.md
@@ -156,7 +156,7 @@ func goschedImpl(gp *g) {
 ```go
 // Goroutine 抢占请求
 // 存储到 g.stackguard0 来导致栈分段检查失败
-// 必须必任何实际的 SP 都要大
+// 必须比任何实际的 SP 都要大
 // 十六进制为：0xfffffade
 const stackPreempt = (1<<(8*sys.PtrSize) - 1) & -1314
 ```

--- a/gosrc/runtime/stack.go
+++ b/gosrc/runtime/stack.go
@@ -114,7 +114,7 @@ const (
 
 	// Goroutine 抢占请求
 	// 存储到 g.stackguard0 来导致栈分段检查失败
-	// 必须必任何实际的 SP 都要大
+	// 必须比任何实际的 SP 都要大
 	// 十六进制为：0xfffffade
 	stackPreempt = uintptrMask & -1314
 


### PR DESCRIPTION
resolve #46 

## 说明

修改了错别字.

## 变化箱单
- 修复了`ch06sched/preemption.md`和`gosrc/runtime/stack.go`的 typo 错误
