### PR TITLE
book: typo fixes in ch04errors/future.md

### DIFF
--- a/book/zh-cn/part1basic/ch04errors/future.md
+++ b/book/zh-cn/part1basic/ch04errors/future.md
@@ -94,7 +94,7 @@ case *CustomError:
 ```
 
 得益于 `fmt.Formatter` 接口，`pkg/errors` 还实现了 `Fomat(fmt.State, rune)` 方法，
-进而在使用 `%+v` 进行错误答应时，能携带堆栈信息：
+进而在使用 `%+v` 进行错误打印时，能携带堆栈信息：
 
 ```go
 func (w *withStack) Format(s fmt.State, verb rune) {


### PR DESCRIPTION

## 说明

修改拼写错误

## 变化箱单

- 修复了 `book/zh-cn/part1basic/ch04errors/future.md` 的 typo 错误
