### PR TITLE
book: typo fixes in ch05sync/mem.md (#59)

### DIFF
--- a/book/zh-cn/part1basic/ch05sync/mem.md
+++ b/book/zh-cn/part1basic/ch05sync/mem.md
@@ -169,7 +169,7 @@ Go 中的 happens before 有以下保证：
 4. channel: 如果 ch 是一个 buffered channel，则 `ch<-val` < `val <- ch`
 5. channel: 如果 ch 是一个 buffered channel 则 `close(ch)` < `val <- ch & val == isZero(val)`
 6. channel: 如果 ch 是一个 unbuffered channel 则，`ch<-val` > `val <- ch`
-7. channel: 如果 ch 是一个 unbuffered channel 则，`len(ch) == C` => `从 channel 中收到第 k 个值` < `k+C 个值得发送完成`
+7. channel: 如果 ch 是一个容量 `len(ch) == C` 的 buffered channel，则 `从 channel 中收到第 k 个值` < `k+C 个值得发送完成`
 8. mutex: 如果对于 sync.Mutex/sync.RWMutex 的锁 l 有 n < m, 则第 n 次调用 `l.Unlock()` < 第 m 次调用 l.Lock() 的返回
 9. mutex: 任何发生在 sync.RWMutex 上的调用 `l.RLock`, 存在一个 n 使得 `l.RLock` > 第 n 次调用 `l.Unlock`，且与之匹配的 `l.RUnlock` < 第 n+1 次调用 l.Lock
 10. once:  f() 在 once.Do(f) 中的调用 < once.Do(f) 的返回


### PR DESCRIPTION
resolve #59

## 说明

修改拼写错误。

## 变化箱单

- 修复了 book/zh-cn/part1basic/ch05sync/mem.md 的 typo 错误
