### PR TITLE
book: typo fixes in ch03lang/map.md

### DIFF
--- a/book/zh-cn/part1basic/ch03lang/map.md
+++ b/book/zh-cn/part1basic/ch03lang/map.md
@@ -350,7 +350,7 @@ var X86 x86
 type CacheLinePad struct{ _ [CacheLinePadSize]byte }
 
 // CacheLineSize 是 CPU 的假设的缓存行大小
-// 当前没有对实际的缓存航大小在运行时检测，因此我们使用针对每个 GOARCH 的 CacheLinePadSize 进行估计
+// 当前没有对实际的缓存行大小在运行时检测，因此我们使用针对每个 GOARCH 的 CacheLinePadSize 进行估计
 var CacheLineSize uintptr = CacheLinePadSize
 
 // x86 中的布尔值包含相应命名的 cpuid 功能位。


### PR DESCRIPTION
## 说明

修改拼写错误。

## 变化箱单

- 修复了 book/zh-cn/part1basic/ch03lang/map.md 的 typo 错误
