### PR TITLE
book: typo fixes in ch03lang/type.md

### DIFF
--- a/book/zh-cn/part1basic/ch03lang/type.md
+++ b/book/zh-cn/part1basic/ch03lang/type.md
@@ -41,32 +41,32 @@ type _type struct {
 
 ```go
 const (
-	kindBool          = 1 + iota // 0000 0010
-	kindInt                      // 0000 0011
-	kindInt8                     // 0000 0100
-	kindInt16                    // 0000 0101
-	kindInt32                    // 0000 0110
-	kindInt64                    // 0000 0111
-	kindUint                     // 0000 1000
-	kindUint8                    // 0000 1001
-	kindUint16                   // 0000 1010
-	kindUint32                   // 0000 1011
-	kindUint64                   // 0000 1100
-	kindUintptr                  // 0000 1101
-	kindFloat32                  // 0000 1110
-	kindFloat64                  // 0000 1111
-	kindComplex64                // 0001 0000
-	kindComplex128               // 0001 0001
-	kindArray                    // 0001 0010
-	kindChan                     // 0001 0011
-	kindFunc                     // 0001 0100
-	kindInterface                // 0001 0101
-	kindMap                      // 0001 0110
-	kindPtr                      // 0001 0111
-	kindSlice                    // 0001 1000
-	kindString                   // 0001 1001
-	kindStruct                   // 0001 1010
-	kindUnsafePointer            // 0001 1011
+	kindBool          = 1 + iota // 0000 0001
+	kindInt                      // 0000 0010
+	kindInt8                     // 0000 0011
+	kindInt16                    // 0000 0100
+	kindInt32                    // 0000 0101
+	kindInt64                    // 0000 0110
+	kindUint                     // 0000 0111
+	kindUint8                    // 0000 1000
+	kindUint16                   // 0000 1001
+	kindUint32                   // 0000 1010
+	kindUint64                   // 0000 1011
+	kindUintptr                  // 0000 1100
+	kindFloat32                  // 0000 1101
+	kindFloat64                  // 0000 1110
+	kindComplex64                // 0000 1111
+	kindComplex128               // 0001 0000
+	kindArray                    // 0001 0001
+	kindChan                     // 0001 0010
+	kindFunc                     // 0001 0011
+	kindInterface                // 0001 0100
+	kindMap                      // 0001 0101
+	kindPtr                      // 0001 0110
+	kindSlice                    // 0001 0111
+	kindString                   // 0001 1000
+	kindStruct                   // 0001 1001
+	kindUnsafePointer            // 0001 1010
 
 	kindDirectIface = 1 << 5       // 0010 0000
 	kindGCProg      = 1 << 6       // 0100 0000


### PR DESCRIPTION
## 说明

修改拼写错误。

## 变化箱单

- 修复了 book/zh-cn/part1basic/ch03lang/type.md 的 typo 错误

