### PR TITLE
book: typo fixes in ch09analysis/readme.md

### DIFF
--- a/book/zh-cn/part3tools/ch09analysis/readme.md
+++ b/book/zh-cn/part3tools/ch09analysis/readme.md
@@ -23,7 +23,7 @@ bookCollapseSection: true
 Everyone knows that debugging is twice as hard as writing a program in the first place. So if you are as clever as you can be when you write it, how will you ever debug it?
 </I></br>
 <div class="quote-right">
--- Brain Kernighan
+-- Brian Kernighan
 </div>
 </div>
 


### PR DESCRIPTION
## 说明

修改拼写错误。

## 变化箱单

- 修复了 /book/zh-cn/part3tools/ch09analysis/readme.md 的 typo 错误

## 参考文献

https://en.wikipedia.org/wiki/Brian_Kernighan
